### PR TITLE
Fix Debian's cloud-init parse error

### DIFF
--- a/init/ds_kvm_deb-sysd.conf
+++ b/init/ds_kvm_deb-sysd.conf
@@ -31,48 +31,46 @@ extra_guest_config:
 ## cloud-init: user data
 # cf. official cloud-init documentation https://cloudinit.readthedocs.io/en/latest/
 cloud_init:
-  hostname: deb-kvm
-  fqdn: deb-kvm.local
-  manage_etc_hosts: true
 
-  timezone: $GS_CITZ
-  locale: $GS_CILOC
+hostname: deb-kvm
+fqdn: deb-kvm.local
+manage_etc_hosts: true
 
-  ssh:
-    emit_keys_to_console: false
+timezone: $GS_CITZ
+locale: $GS_CILOC
 
-  disable_root: true
-  allow_public_ssh_keys: true
+ssh:
+  emit_keys_to_console: false
 
-  users: 
-    - name: $GS_CIUSER
-      groups: [adm, sudo, wheel]
-      sudo: ALL=(ALL) NOPASSWD:ALL
-      lock_passwd: false
-      passwd: $GS_CIPASSWD_SHA
-      shell: /bin/bash
-      ssh_authorized_keys:
-      $GS_SSHKEY
-  
-  chpasswd:
-    expire: false 
+disable_root: true
+allow_public_ssh_keys: true
 
-  package_update: true
-  package_upgrade: true
+users: 
+  - name: $GS_CIUSER
+    groups: [adm, sudo, wheel]
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    lock_passwd: false
+    passwd: $GS_CIPASSWD_SHA
+    shell: /bin/bash
+    ssh_authorized_keys:
+    $GS_SSHKEY
 
-  packages:
-    - qemu-guest-agent
-    - openssh-server
+chpasswd:
+  expire: false 
 
-  bootcmd:
-    - [ cloud-init-per, once, cleanlocale_00, sed, -i, 's/^#\s*\($GS_CILOC UTF-8\)/\1/', /etc/locale.gen ]
-    - [ cloud-init-per, once, cleanlocale_01, locale-gen ]
-    - [ cloud-init-per, once, cleanlocale_02, update-locale, LANG=$GS_CILOC, LANGUAGE=$GS_CILOC, LC_ALL=$GS_CILOC ]
+packages:
+  - qemu-guest-agent
+  - openssh-server
 
-  runcmd:
-    - systemctl enable sshd.service
-    - systemctl enable qemu-guest-agent.service
-    - systemctl start sshd.service
-    - systemctl start qemu-guest-agent.service
+bootcmd:
+  - [ cloud-init-per, once, cleanlocale_00, sed, -i, 's/^#\s*\($GS_CILOC UTF-8\)/\1/', /etc/locale.gen ]
+  - [ cloud-init-per, once, cleanlocale_01, locale-gen ]
+  - [ cloud-init-per, once, cleanlocale_02, update-locale, LANG=$GS_CILOC, LANGUAGE=$GS_CILOC, LC_ALL=$GS_CILOC ]
 
-  final_message: 'Debian guest has been initialized'
+runcmd:
+  - systemctl enable sshd.service
+  - systemctl enable qemu-guest-agent.service
+  - systemctl start sshd.service
+  - systemctl start qemu-guest-agent.service
+
+final_message: 'Debian guest has been initialized'

--- a/init/ds_lxc_deb-init.conf
+++ b/init/ds_lxc_deb-init.conf
@@ -27,42 +27,43 @@ extra_guest_config:
 ## cloud-init: user data
 # cf. official cloud-init documentation https://cloudinit.readthedocs.io/en/latest/
 cloud_init:
-  hostname: deb-lxc
-  fqdn: deb-lxc.local
-  manage_etc_hosts: true
 
-  timezone: $GS_CITZ
-  locale: $GS_CILOC
+hostname: deb-lxc
+fqdn: deb-lxc.local
+manage_etc_hosts: true
 
-  ssh:
-    emit_keys_to_console: false
+timezone: $GS_CITZ
+locale: $GS_CILOC
 
-  disable_root: true
-  allow_public_ssh_keys: true
+ssh:
+  emit_keys_to_console: false
 
-  users: 
-    - name: $GS_CIUSER
-      groups: [adm, sudo, wheel]
-      sudo: ALL=(ALL) NOPASSWD:ALL
-      lock_passwd: false
-      passwd: $GS_CIPASSWD_SHA
-      shell: /bin/bash
-      ssh_authorized_keys:
-      $GS_SSHKEY
+disable_root: true
+allow_public_ssh_keys: true
 
-  chpasswd:
-      expire: false 
+users: 
+  - name: $GS_CIUSER
+    groups: [adm, sudo, wheel]
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    lock_passwd: false
+    passwd: $GS_CIPASSWD_SHA
+    shell: /bin/bash
+    ssh_authorized_keys:
+    $GS_SSHKEY
 
-  package_update: true
-  package_upgrade: true
+chpasswd:
+    expire: false 
 
-  bootcmd:
-    - [ cloud-init-per, once, locale00, sed, -i, 's/^#\s*\($GS_CILOC UTF-8\)/\1/', /etc/locale.gen ]
-    - [ cloud-init-per, once, locale01, locale-gen ]
-    - [ cloud-init-per, once, locale02, update-locale, $GS_CILOC ]
+package_update: true
+package_upgrade: true
 
-  runcmd:
-    - service ssh enable
-    - service ssh start
+bootcmd:
+  - [ cloud-init-per, once, locale00, sed, -i, 's/^#\s*\($GS_CILOC UTF-8\)/\1/', /etc/locale.gen ]
+  - [ cloud-init-per, once, locale01, locale-gen ]
+  - [ cloud-init-per, once, locale02, update-locale, $GS_CILOC ]
 
-  final_message: 'Debian SysVinit guest has been initialized'
+runcmd:
+  - service ssh enable
+  - service ssh start
+
+final_message: 'Debian SysVinit guest has been initialized'

--- a/init/ds_lxc_deb-sysd.conf
+++ b/init/ds_lxc_deb-sysd.conf
@@ -27,42 +27,43 @@ extra_guest_config:
 ## cloud-init: user data
 # cf. official cloud-init documentation https://cloudinit.readthedocs.io/en/latest/
 cloud_init:
-  hostname: deb-lxc
-  fqdn: deb-lxc.local
-  manage_etc_hosts: true
 
-  timezone: $GS_CITZ
-  locale: $GS_CILOC
+hostname: deb-lxc
+fqdn: deb-lxc.local
+manage_etc_hosts: true
 
-  ssh:
-    emit_keys_to_console: false
+timezone: $GS_CITZ
+locale: $GS_CILOC
 
-  disable_root: true
-  allow_public_ssh_keys: true
+ssh:
+  emit_keys_to_console: false
 
-  users: 
-    - name: $GS_CIUSER
-      groups: [adm, sudo, wheel]
-      sudo: ALL=(ALL) NOPASSWD:ALL
-      lock_passwd: false
-      passwd: $GS_CIPASSWD_SHA
-      shell: /bin/bash
-      ssh_authorized_keys:
-      $GS_SSHKEY
+disable_root: true
+allow_public_ssh_keys: true
 
-  chpasswd:
-      expire: false 
+users: 
+  - name: $GS_CIUSER
+    groups: [adm, sudo, wheel]
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    lock_passwd: false
+    passwd: $GS_CIPASSWD_SHA
+    shell: /bin/bash
+    ssh_authorized_keys:
+    $GS_SSHKEY
 
-  package_update: true
-  package_upgrade: true
+chpasswd:
+    expire: false 
 
-  bootcmd:
-    - [ cloud-init-per, once, clocale00, sed, -i, 's/^#\s*\($GS_CILOC UTF-8\)/\1/', /etc/locale.gen ]
-    - [ cloud-init-per, once, clocale01, locale-gen ]
-    - [ cloud-init-per, once, clocale02, update-locale, $GS_CILOC ]
+package_update: true
+package_upgrade: true
 
-  runcmd:
-    - systemctl enable sshd.service
-    - systemctl start sshd.service
+bootcmd:
+  - [ cloud-init-per, once, clocale00, sed, -i, 's/^#\s*\($GS_CILOC UTF-8\)/\1/', /etc/locale.gen ]
+  - [ cloud-init-per, once, clocale01, locale-gen ]
+  - [ cloud-init-per, once, clocale02, update-locale, $GS_CILOC ]
 
-  final_message: 'Debian systemd guest has been initialized'
+runcmd:
+  - systemctl enable sshd.service
+  - systemctl start sshd.service
+
+final_message: 'Debian systemd guest has been initialized'


### PR DESCRIPTION
Debian's cloud-init needs strict YAML indent.
(Perhaps other distribution also requires this. But I only test Debian now...)
